### PR TITLE
Eklenti ve woocommerce uyumluluk hatasını düzelt

### DIFF
--- a/ai-inventory-agent.php
+++ b/ai-inventory-agent.php
@@ -88,8 +88,11 @@ register_deactivation_hook(__FILE__, function() {
 });
 
 // Uninstall hook
-register_uninstall_hook(__FILE__, function() {
+register_uninstall_hook(__FILE__, 'aia_uninstall_plugin');
+
+// Uninstall callback function
+function aia_uninstall_plugin() {
     if (class_exists('AIA\\Core\\Uninstaller')) {
         AIA\Core\Uninstaller::uninstall();
     }
-});
+}


### PR DESCRIPTION
Replaces anonymous function with a named function for the uninstall hook to fix a serialization error.

---
<a href="https://cursor.com/background-agent?bcId=bc-6f8ace51-578c-4747-a9eb-6cc379402790">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6f8ace51-578c-4747-a9eb-6cc379402790">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

